### PR TITLE
fix: recover from stale PulseAudio sockets on Pi OS Lite

### DIFF
--- a/deployment/birdnet-service.sh
+++ b/deployment/birdnet-service.sh
@@ -117,8 +117,15 @@ reset_stale_system_pulseaudio() {
 
     log_warning "System PulseAudio socket exists but server is not responding; resetting stale runtime files..."
 
-    sudo pulseaudio --kill 2>/dev/null || true
-    sudo rm -f "$system_socket" "$system_pid_file"
+    sudo -n pulseaudio --kill 2>/dev/null || true
+
+    if ! sudo -n rm -f "$system_socket"; then
+        log_warning "Failed to remove stale PulseAudio socket $system_socket"
+    fi
+
+    if ! sudo -n rm -f "$system_pid_file"; then
+        log_warning "Failed to remove stale PulseAudio pid file $system_pid_file"
+    fi
 }
 
 # Function to ensure PulseAudio socket is available at /run/pulse/native

--- a/deployment/birdnet-service.sh
+++ b/deployment/birdnet-service.sh
@@ -105,6 +105,22 @@ ensure_pulse_dir_permissions() {
     log_debug "Ensured permissions on $pulse_dir (755, pulse:pulse-access)"
 }
 
+is_pulseaudio_responding() {
+    local socket_path="$1"
+    PULSE_SERVER="unix:$socket_path" pactl info >/dev/null 2>&1
+}
+
+reset_stale_system_pulseaudio() {
+    local system_pulse_dir="$1"
+    local system_socket="$2"
+    local system_pid_file="$system_pulse_dir/pid"
+
+    log_warning "System PulseAudio socket exists but server is not responding; resetting stale runtime files..."
+
+    sudo pulseaudio --kill 2>/dev/null || true
+    sudo rm -f "$system_socket" "$system_pid_file"
+}
+
 # Function to ensure PulseAudio socket is available at /run/pulse/native
 # This works for both:
 #   - Pi OS Desktop: PipeWire provides user socket, we bind-mount it to /run/pulse
@@ -183,7 +199,12 @@ setup_audio_socket() {
         # This handles cases where PulseAudio was started manually or by another process
         # with restrictive permissions (see GitHub issue #6)
         ensure_pulse_dir_permissions "$system_pulse_dir"
-        return 0
+        if is_pulseaudio_responding "$system_socket"; then
+            log_info "System PulseAudio is responding"
+            return 0
+        fi
+
+        reset_stale_system_pulseaudio "$system_pulse_dir" "$system_socket"
     fi
 
     # Case 3: No socket found - start system-wide PulseAudio (Pi OS Lite)
@@ -213,7 +234,7 @@ setup_audio_socket() {
     done
 
     # Verify PulseAudio is actually responding (not just socket exists)
-    if PULSE_SERVER=unix:$system_socket pactl info >/dev/null 2>&1; then
+    if is_pulseaudio_responding "$system_socket"; then
         log_info "System PulseAudio started (socket: $system_socket)"
     else
         log_warning "PulseAudio socket exists but server not responding"

--- a/install.sh
+++ b/install.sh
@@ -748,6 +748,7 @@ $ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin mkdir) -p /run/pulse
 $ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin chown) pulse\:pulse-access /run/pulse
 $ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin chmod) 755 /run/pulse
 $ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin rm) -f /run/pulse/native
+$ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin rm) -f /run/pulse/pid
 
 # Enable swap (optional, only if /swapfile-birdnet-pipy exists)
 $ACTUAL_USER ALL=(ALL) NOPASSWD: $(_bin swapon) /swapfile-birdnet-pipy


### PR DESCRIPTION
## Summary

On Pi OS Lite, BirdNET-PiPy can start up with a stale `/run/pulse/native` socket left behind after PulseAudio has died.

When that happens, `deployment/birdnet-service.sh` sees the socket, assumes PulseAudio is available, and continues booting the containers. The `main` container then fails later when ffmpeg tries to record from PulseAudio:

- `PulseAudio recording failed: [in] Error opening input: No such process`

At the same time, running `pactl info` on the host returns `Connection refused`, so the socket exists but nothing is serving it.

## Changes made

This updates the system-wide PulseAudio path in `deployment/birdnet-service.sh`.

If `/run/pulse/native` already exists, the script now checks that PulseAudio actually responds before treating the socket as valid. If the check fails, it:

- logs that the existing socket is stale
- kills any leftover PulseAudio process
- removes the stale socket and pid file
- continues through the normal system-wide PulseAudio startup path

I also pulled the `pactl info` check into a small helper and reused it after fresh startup, so both paths use the same health check.

## Notes

This only changes the system-wide PulseAudio startup path used on Lite installs. Desktop audio handling is unchanged.

I hit this while testing BirdNET-PiPy on a Pi 4 with a USB mic. The mic was present in ALSA, the app settings were correct, and BirdNET was configured to use `device: "default"`, but startup still failed because the existing PulseAudio socket was stale.